### PR TITLE
Updating to the new quay.io wildfly image stream

### DIFF
--- a/creator/src/main/kotlin/io/fabric8/launcher/creator/cli/generate.kt
+++ b/creator/src/main/kotlin/io/fabric8/launcher/creator/cli/generate.kt
@@ -3,7 +3,7 @@ package io.fabric8.launcher.creator.cli
 import com.github.ajalt.clikt.core.CliktCommand
 import io.fabric8.launcher.creator.core.resource.generate
 
-class Generate : CliktCommand(help = "Generates all the OpenShift tempaltes needed for the Creator to work") {
+class Generate : CliktCommand(help = "Generates all the OpenShift templates needed for the Creator to work") {
     override fun run() {
         generate()
     }

--- a/creator/src/main/kotlin/io/fabric8/launcher/creator/core/resource/images.kt
+++ b/creator/src/main/kotlin/io/fabric8/launcher/creator/core/resource/images.kt
@@ -7,7 +7,7 @@ import java.nio.file.Paths
 
 const val BUILDER_DOTNET = "registry.access.redhat.com/dotnet/dotnet-22-rhel7"
 const val BUILDER_JAVA = "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift"
-const val BUILDER_JAVAEE = "openshift/wildfly:latest"
+const val BUILDER_JAVAEE = "quay.io/wildfly/wildfly-centos7"
 const val BUILDER_NODEJS_APP = "nodeshift/centos7-s2i-nodejs"
 const val BUILDER_NODEJS_WEB = "nodeshift/centos7-s2i-web-app"
 

--- a/creator/src/main/resources/META-INF/catalog/generators/app-images/resources/quay.io_wildfly_wildfly-centos7.yaml
+++ b/creator/src/main/resources/META-INF/catalog/generators/app-images/resources/quay.io_wildfly_wildfly-centos7.yaml
@@ -5,6 +5,27 @@ objects:
     creationTimestamp: null
     labels:
       app: {{.application}}
+    name: wildfly-centos7
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - from:
+        kind: DockerImage
+        name: quay.io/wildfly/wildfly-centos7
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ''
+  status:
+    dockerImageRepository: ''
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: {{.application}}
     name: {{.serviceName}}
   spec:
     lookupPolicy:
@@ -34,8 +55,7 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: wildfly:latest
-          namespace: openshift
+          name: wildfly-centos7:latest
         incremental: true
       type: Source
     triggers:
@@ -74,6 +94,8 @@ objects:
           ports:
           - containerPort: 8080
             protocol: TCP
+          - containerPort: 8778
+            protocol: TCP
           resources: {}
     test: false
     triggers:
@@ -106,6 +128,10 @@ objects:
       port: 8080
       protocol: TCP
       targetPort: 8080
+    - name: 8778-tcp
+      port: 8778
+      protocol: TCP
+      targetPort: 8778
     selector:
       app: {{.application}}
       deploymentconfig: {{.serviceName}}

--- a/creator/src/main/resources/META-INF/catalog/generators/app-images/resources/registry.access.redhat.com_redhat-openjdk-18_openjdk18-openshift.yaml
+++ b/creator/src/main/resources/META-INF/catalog/generators/app-images/resources/registry.access.redhat.com_redhat-openjdk-18_openjdk18-openshift.yaml
@@ -92,11 +92,11 @@ objects:
         - image: {{.serviceName}}:latest
           name: {{.serviceName}}
           ports:
+          - containerPort: 8443
+            protocol: TCP
           - containerPort: 8778
             protocol: TCP
           - containerPort: 8080
-            protocol: TCP
-          - containerPort: 8443
             protocol: TCP
           resources: {}
     test: false

--- a/creator/src/main/resources/META-INF/catalog/generators/runtime-wildfly/info.yaml
+++ b/creator/src/main/resources/META-INF/catalog/generators/runtime-wildfly/info.yaml
@@ -6,4 +6,4 @@ config:
   memoryLimit: 1Gi
   props:
     jarName: ROOT.war
-    builderImage: openshift/wildfly:latest
+    builderImage: quay.io/wildfly/wildfly-centos7

--- a/creator/src/main/resources/META-INF/resource/images.yaml
+++ b/creator/src/main/resources/META-INF/resource/images.yaml
@@ -9,7 +9,7 @@
     language: java
     binaryExt: jar
     isBuilder: true
-- id: openshift/wildfly:latest
+- id: quay.io/wildfly/wildfly-centos7
   name: JavaEE Code Builder
   metadata:
     language: java

--- a/launcher-env-template.sh
+++ b/launcher-env-template.sh
@@ -68,9 +68,10 @@ case "$KEYCLOAK" in
         echo "WARNING: MiniShift is NOT running, start it and try again or make sure the following variables are set:"
         echo "   LAUNCHER_MISSIONCONTROL_OPENSHIFT_API_URL"
         echo "   LAUNCHER_MISSIONCONTROL_OPENSHIFT_CONSOLE_URL"
+	return
     else
         export LAUNCHER_MISSIONCONTROL_OPENSHIFT_API_URL=$MSHIFT
-        export LAUNCHER_MISSIONCONTROL_OPENSHIFT_CONSOLE_URL=$MSHIFT
+        export LAUNCHER_MISSIONCONTROL_OPENSHIFT_CONSOLE_URL=$MSHIFT/console
     fi
 
     export LAUNCHER_MISSIONCONTROL_OPENSHIFT_USERNAME=developer


### PR DESCRIPTION
### Why
Update the configuration to use the 'official' Wildfly images stream

### Description
Change the image stream name to point to quay.io.


https://github.com/fabric8-launcher/launcher-application/issues/925
