### PR TITLE
bump commons-compress to 1.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <version.okio>2.3.0</version.okio>
     <version.cache2k>1.2.4.Final</version.cache2k>
     <version.commons.codec>1.13</version.commons.codec>
-    <version.commons.compress>1.18</version.commons.compress>
+    <version.commons.compress>1.19</version.commons.compress>
     <version.commons.io>2.6</version.commons.io>
     <version.commons.lang3>3.9</version.commons.lang3>
     <version.commons.text>1.8</version.commons.text>


### PR DESCRIPTION
Fixes CVE-2019-12402 

The file name encoding algorithm used internally in Apache Commons Compress 1.15 to 1.18 can get into an infinite loop when faced with specially crafted inputs. This can lead to a denial of service attack if an attacker can choose the file names inside of an archive created by Compress.
